### PR TITLE
Add from_effect param to trigger_enter to prevent enter effects firin…

### DIFF
--- a/scripts/action_handler.gd
+++ b/scripts/action_handler.gd
@@ -269,7 +269,7 @@ func _rank_up_monster(state: GameState, opponent: PlayerState, winner_player_id:
 		monster_countered.emit(opponent.player_id, old_monster, m)
 		opponent.monster_changed.emit()
 		if effect_handler:
-			await effect_handler.trigger_enter(opponent.player_id, m)
+			await effect_handler.trigger_enter(opponent.player_id, m, true)
 	else:
 		# Opponent loses - can't find valid rank-up monster
 		state.game_over.emit(winner_player_id, "Victory through countering!")
@@ -296,7 +296,7 @@ func play_monster_from_effect(state: GameState, player_id: int, monster_card: Di
 	monster_played.emit(player_id, old_monster, monster_card)
 	player.monster_changed.emit()
 	if effect_handler:
-		await effect_handler.trigger_enter(player_id, monster_card)
+		await effect_handler.trigger_enter(player_id, monster_card, true)
 		await effect_handler.trigger_monster_played(player_id, old_monster, monster_card)
 
 

--- a/scripts/effects/ebp01/ebp01_019.gd
+++ b/scripts/effects/ebp01/ebp01_019.gd
@@ -55,10 +55,9 @@ func on_enter(ctx: EffectContext) -> void:
 			EffectHandler.banish_or_discard(ctx.owner, destroyed_stack)
 			ctx.owner.discard_changed.emit()
 
-		selected["played_from_effect"] = true
 		ctx.owner.push_zone_card(target_zone, selected)
 		ctx.owner.zones_changed.emit()
-		await ctx.effect_handler.trigger_enter(ctx.owner.player_id, selected)
+		await ctx.effect_handler.trigger_enter(ctx.owner.player_id, selected, true)
 
 		# Rule 5.11.1.3: must play to different zones if possible
 		valid_zones.erase(target_zone)

--- a/scripts/effects/ebp01/ebp01_034.gd
+++ b/scripts/effects/ebp01/ebp01_034.gd
@@ -50,4 +50,4 @@ func on_enter(ctx: EffectContext) -> void:
 
 	ctx.owner.push_zone_card(target_zone, selected)
 	ctx.owner.zones_changed.emit()
-	await ctx.effect_handler.trigger_enter(ctx.owner.player_id, selected)
+	await ctx.effect_handler.trigger_enter(ctx.owner.player_id, selected, true)

--- a/scripts/effects/ebp01/ebp01_060.gd
+++ b/scripts/effects/ebp01/ebp01_060.gd
@@ -48,4 +48,4 @@ func on_enter(ctx: EffectContext) -> void:
 	ctx.owner.strategy_zones[sz_index] = selected
 	ctx.owner.strategy_zone_turn_placed[sz_index] = ctx.game_state.turn_number
 	ctx.owner.strategy_zones_changed.emit()
-	await ctx.effect_handler.trigger_enter(ctx.owner.player_id, selected)
+	await ctx.effect_handler.trigger_enter(ctx.owner.player_id, selected, true)

--- a/scripts/effects/ebp02/ebp02_t04.gd
+++ b/scripts/effects/ebp02/ebp02_t04.gd
@@ -50,4 +50,4 @@ func on_phase_start(ctx: EffectContext, phase: CardEnums.GamePhase) -> void:
 	# Play selected Chibi Godzilla to the zone this token was in
 	ctx.owner.push_zone_card(zone_idx, selected)
 	ctx.owner.zones_changed.emit()
-	await ctx.effect_handler.trigger_enter(ctx.owner.player_id, selected)
+	await ctx.effect_handler.trigger_enter(ctx.owner.player_id, selected, true)

--- a/scripts/effects/ebp03/ebp03_012.gd
+++ b/scripts/effects/ebp03/ebp03_012.gd
@@ -77,5 +77,5 @@ func on_enter(ctx: EffectContext) -> void:
 				ctx.owner.strategy_zones_changed.emit()
 			ctx.owner.discard_changed.emit()
 			# Trigger enter for the strategy card
-			await ctx.effect_handler.trigger_enter(ctx.owner.player_id, card)
+			await ctx.effect_handler.trigger_enter(ctx.owner.player_id, card, true)
 			break

--- a/scripts/effects/ebp03/ebp03_036.gd
+++ b/scripts/effects/ebp03/ebp03_036.gd
@@ -54,6 +54,5 @@ func on_enter(ctx: EffectContext) -> void:
 		ctx.owner.discard_changed.emit()
 
 	ctx.owner.push_zone_card(dest, found)
-	found["played_from_effect"] = true
 	ctx.owner.zones_changed.emit()
-	await ctx.effect_handler.trigger_enter(ctx.owner.player_id, found)
+	await ctx.effect_handler.trigger_enter(ctx.owner.player_id, found, true)

--- a/scripts/effects/ebp03/ebp03_043.gd
+++ b/scripts/effects/ebp03/ebp03_043.gd
@@ -85,4 +85,4 @@ func on_phase_start(ctx: EffectContext, phase: CardEnums.GamePhase) -> void:
 	if not selected.is_empty():
 		ctx.owner.push_zone_card(chosen, selected)
 		ctx.owner.zones_changed.emit()
-		await ctx.effect_handler.trigger_enter(ctx.owner.player_id, selected)
+		await ctx.effect_handler.trigger_enter(ctx.owner.player_id, selected, true)

--- a/scripts/effects/ebp03/ebp03_047.gd
+++ b/scripts/effects/ebp03/ebp03_047.gd
@@ -57,4 +57,4 @@ func on_phase_start(ctx: EffectContext, phase: CardEnums.GamePhase) -> void:
 	# Play on top of this card in the same zone
 	ctx.owner.push_zone_card(zone_idx, found)
 	ctx.owner.zones_changed.emit()
-	await ctx.effect_handler.trigger_enter(ctx.owner.player_id, found)
+	await ctx.effect_handler.trigger_enter(ctx.owner.player_id, found, true)

--- a/scripts/effects/ebp03/ebp03_080.gd
+++ b/scripts/effects/ebp03/ebp03_080.gd
@@ -82,5 +82,5 @@ func on_phase_start(ctx: EffectContext, phase: CardEnums.GamePhase) -> void:
 
 			ctx.owner.push_zone_card(dest, card)
 			ctx.owner.zones_changed.emit()
-			await ctx.effect_handler.trigger_enter(ctx.owner.player_id, card)
+			await ctx.effect_handler.trigger_enter(ctx.owner.player_id, card, true)
 			break

--- a/scripts/effects/effect_handler.gd
+++ b/scripts/effects/effect_handler.gd
@@ -303,9 +303,12 @@ func _resolve_player_standby(player_id: int, entries: Array) -> void:
 
 # --- Trigger dispatchers ---
 
-func trigger_enter(player_id: int, card_data: Dictionary) -> void:
+func trigger_enter(player_id: int, card_data: Dictionary, from_effect: bool = false) -> void:
 	## Trigger <Enter> effect on the card that just entered play.
+	## If from_effect is true, marks the card so enter effects know it wasn't played from hand.
 	## If inside standby resolution, defers the enter to the pending queue (10.4.3).
+	if from_effect:
+		card_data["played_from_effect"] = true
 	if not has_trigger(card_data, "on_enter"):
 		return
 	var effect := get_effect(card_data)
@@ -1393,10 +1396,9 @@ func perform_evolution(player_id: int, zone_idx: int) -> bool:
 	card_evolved.emit(player_id, selected, zone_idx)
 	# Mark as played through evolution for enter effects (e.g. ESD02-010)
 	selected["played_through_evolution"] = true
-	selected["played_from_effect"] = true
 	player.push_zone_card(zone_idx, selected)
 	player.zones_changed.emit()
-	await trigger_enter(player_id, selected)
+	await trigger_enter(player_id, selected, true)
 	return true
 
 
@@ -1615,7 +1617,7 @@ func create_token_in_zone(player: PlayerState, token_id: String, zone_index: int
 
 	player.push_zone_card(zone_index, token_data)
 	player.zones_changed.emit()
-	await trigger_enter(player.player_id, token_data)
+	await trigger_enter(player.player_id, token_data, true)
 	# Tokens are treated as normal plays — trigger battle card played effects
 	# (but not considered played from hand).
 	if token_data.get("card_type") == CardEnums.CardType.BATTLE:
@@ -2228,7 +2230,7 @@ func play_from_discard(player_id: int, card_data: Dictionary, zone_idx: int = -1
 
 	player.push_zone_card(zone_idx, card_data)
 	player.zones_changed.emit()
-	await trigger_enter(player_id, card_data)
+	await trigger_enter(player_id, card_data, true)
 	return zone_idx
 
 

--- a/scripts/effects/esd01/esd01_014.gd
+++ b/scripts/effects/esd01/esd01_014.gd
@@ -50,4 +50,4 @@ func on_enter(ctx: EffectContext) -> void:
 
 		player.push_zone_card(target_zone, selected)
 		player.zones_changed.emit()
-		await ctx.effect_handler.trigger_enter(player.player_id, selected)
+		await ctx.effect_handler.trigger_enter(player.player_id, selected, true)

--- a/scripts/effects/esd02/esd02_003.gd
+++ b/scripts/effects/esd02/esd02_003.gd
@@ -70,7 +70,7 @@ func on_enter(ctx: EffectContext) -> void:
 
 		player.push_zone_card(target_zone, selected)
 		player.zones_changed.emit()
-		await ctx.effect_handler.trigger_enter(player.player_id, selected)
+		await ctx.effect_handler.trigger_enter(player.player_id, selected, true)
 
 		# Rule 5.11.1.3: must play to different zones if possible
 		valid_adjacent.erase(target_zone)


### PR DESCRIPTION
…g when not played from hand

EBP03-036 (Moguera) was incorrectly letting the player search deck when played from EBP03-043 (Star Falcon) because the played_from_effect flag wasn't being set. Instead of requiring every caller to manually set the flag, trigger_enter now accepts a from_effect parameter that handles it.