### PR TITLE
Fix burst interaction with play_monster_from_effect (130 Million Years)

### DIFF
--- a/scripts/action_handler.gd
+++ b/scripts/action_handler.gd
@@ -291,6 +291,13 @@ func play_monster_from_effect(state: GameState, player_id: int, monster_card: Di
 	if not old_monster.is_empty():
 		player.monster_stack.push_front(old_monster)
 
+	# If a burst monster is active, the new monster buries it in the stack.
+	# Clear burst state so the burst card isn't discarded at end of turn.
+	if not player.burst_monster.is_empty():
+		player.burst_monster = {}
+		player.pre_burst_monster = {}
+
+	player.has_played_monster_this_turn = true
 	player.current_monster = monster_card
 	player.monster_deck.erase(monster_card)
 	monster_played.emit(player_id, old_monster, monster_card)


### PR DESCRIPTION
When a new monster is played from an effect on top of a burst monster, clear burst state so the burst card stays buried in the stack instead of being discarded at end of turn. Also set has_played_monster_this_turn to prevent additional monster plays from hand after the effect resolves.