### PR TITLE
Allow crystal tokens to be placed in occupied zones (#153)

### DIFF
--- a/scripts/effects/ebp02/ebp02_052.gd
+++ b/scripts/effects/ebp02/ebp02_052.gd
@@ -31,4 +31,4 @@ func on_when_invading(ctx: EffectContext, _from_zone: int, _to_zone: int) -> voi
 		return
 
 	# Place a Crystals token in an empty zone
-	await ctx.effect_handler.create_tokens_in_empty_zones(ctx.owner, "EBP02-T03", 1)
+	await ctx.effect_handler.create_tokens_in_zones(ctx.owner, "EBP02-T03", 1)

--- a/scripts/effects/ebp02/ebp02_053.gd
+++ b/scripts/effects/ebp02/ebp02_053.gd
@@ -17,7 +17,7 @@ func get_bot_tags() -> Array[String]:
 
 
 func on_when_invading(ctx: EffectContext, _from_zone: int, _to_zone: int) -> void:
-	await ctx.effect_handler.create_tokens_in_empty_zones(ctx.owner, "EBP02-T03", 1)
+	await ctx.effect_handler.create_tokens_in_zones(ctx.owner, "EBP02-T03", 1)
 
 
 func get_threat_level_modifier(ctx: EffectContext) -> int:

--- a/scripts/effects/ebp02/ebp02_054.gd
+++ b/scripts/effects/ebp02/ebp02_054.gd
@@ -22,7 +22,7 @@ func get_bot_destroy_max_rank(_owner: PlayerState, _opponent: PlayerState) -> in
 
 
 func on_enter(ctx: EffectContext) -> void:
-	await ctx.effect_handler.create_tokens_in_empty_zones(ctx.owner, "EBP02-T03", 2)
+	await ctx.effect_handler.create_tokens_in_zones(ctx.owner, "EBP02-T03", 2)
 
 
 func on_rage_changed(ctx: EffectContext, old_rage: int, new_rage: int) -> void:

--- a/scripts/effects/ebp02/ebp02_057.gd
+++ b/scripts/effects/ebp02/ebp02_057.gd
@@ -56,4 +56,4 @@ func on_rage_changed(ctx: EffectContext, old_rage: int, new_rage: int) -> void:
 	# Only trigger when rage increases
 	if new_rage <= old_rage:
 		return
-	await ctx.effect_handler.create_tokens_in_empty_zones(ctx.owner, "EBP02-T03", 2)
+	await ctx.effect_handler.create_tokens_in_zones(ctx.owner, "EBP02-T03", 2)

--- a/scripts/effects/effect_handler.gd
+++ b/scripts/effects/effect_handler.gd
@@ -1668,19 +1668,29 @@ func create_token_in_zone(player: PlayerState, token_id: String, zone_index: int
 	return true
 
 
-func create_tokens_in_empty_zones(player: PlayerState, token_id: String, count: int) -> int:
-	## Let the player select empty zones to place up to count tokens.
+func create_tokens_in_zones(player: PlayerState, token_id: String, count: int) -> int:
+	## Let the player select zones to place up to count tokens.
+	## Tokens can overload occupied zones. When placing multiple tokens from
+	## one effect, each must go to a different zone.
 	## Returns the number of tokens actually placed.
 	var placed: int = 0
+	var used_zones: Array[int] = []
 	for _i in range(count):
-		var empty := player.get_empty_zone_indices()
-		if empty.is_empty():
+		var valid: Array[int] = []
+		for i in range(8):
+			if i == player.monster_zone - 1:
+				continue
+			if i in used_zones:
+				continue
+			valid.append(i)
+		if valid.is_empty():
 			break
 		var chosen: int = await select_zone_target(
-			player.player_id, player.player_id, empty,
-			"Choose an empty zone for a token (%d remaining):" % (count - placed))
+			player.player_id, player.player_id, valid,
+			"Choose a zone for a token (%d remaining):" % (count - placed))
 		if chosen < 0:
 			break
+		used_zones.append(chosen)
 		if await create_token_in_zone(player, token_id, chosen):
 			placed += 1
 	return placed


### PR DESCRIPTION
Crystals can now overload occupied zones instead of being restricted to empty zones only. When placing multiple crystals from one effect, each must still go to a different zone.