### PR TITLE
Fix EBP01-042 to prompt discard even when opponent rage is 0

### DIFF
--- a/scripts/effects/ebp01/ebp01_042.gd
+++ b/scripts/effects/ebp01/ebp01_042.gd
@@ -18,9 +18,7 @@ func get_bot_tags() -> Array[String]:
 	return ["boosts_threat", "weakens_opponent"]
 
 
-func bot_can_fulfill_on_enter(owner: PlayerState, opponent: PlayerState) -> bool:
-	if opponent.rage <= 0:
-		return false
+func bot_can_fulfill_on_enter(owner: PlayerState, _opponent: PlayerState) -> bool:
 	var monster_count: int = 0
 	for card in owner.discard_pile:
 		if card.get("card_type") == CardEnums.CardType.MONSTER:
@@ -42,8 +40,6 @@ func bot_can_fulfill_threat_level(owner: PlayerState, _opponent: PlayerState) ->
 
 func on_enter(ctx: EffectContext) -> void:
 	if ctx.effect_handler.count_monsters_in_discard(ctx.owner) < 5:
-		return
-	if ctx.opponent.rage <= 0:
 		return
 
 	var discarded := await ctx.effect_handler.select_hand_card(


### PR DESCRIPTION
The card text says "you may discard 1 card from your hand to reduce your opponent's Rage by 1" — the player should always be prompted when the 5-monster condition is met, regardless of opponent rage.