### PR TITLE
Fix replay viewer board layout after loading save as player 2

### DIFF
--- a/scenes/ui/replay_viewer.gd
+++ b/scenes/ui/replay_viewer.gd
@@ -65,6 +65,10 @@ func _ready() -> void:
 		turn_label.text = "No replay data"
 		return
 
+	# Reset local_player_id so PlayerBoard layouts are correct
+	# (may be stale from loading a save as player 2)
+	NetworkManager.local_player_id = 0
+
 	# Create player boards
 	player2_board = player_board_scene.instantiate()
 	player2_board.player_id = 1


### PR DESCRIPTION
Reset NetworkManager.local_player_id before creating PlayerBoard instances so rage/threat positioning, custom playmat, and card back orientation are correct regardless of prior session state.

Fixes #162