### PR TITLE
Fix pending-effect hover killing the attention pulse tween

### DIFF
--- a/scenes/cards/card.gd
+++ b/scenes/cards/card.gd
@@ -659,7 +659,9 @@ func set_highlight(enabled: bool) -> void:
 			add_child(overlay)
 		overlay.visible = true
 	elif overlay:
-		overlay.queue_free()
+		# Hide, never queue_free(): a same-frame re-enable would fetch the
+		# queued-for-deletion node and the highlight would silently vanish.
+		overlay.visible = false
 
 
 var _attention_tween: Tween = null
@@ -706,7 +708,13 @@ func set_attention_highlight(enabled: bool, border_color: Color = Color(0.25, 0.
 		_attention_tween.tween_property(overlay, "modulate:a", 0.4, 0.4)
 		_attention_tween.tween_property(overlay, "modulate:a", 1.0, 0.4)
 	elif overlay:
-		overlay.queue_free()
+		# Hide, never queue_free(): moving the mouse between two stack rows
+		# that target the same card disables and re-enables this highlight in
+		# the same frame, so a freed overlay would be picked up again above and
+		# the looping tween would target a dead node ("Infinite loop detected"
+		# in tween.cpp once every tweener turns invalid).
+		overlay.visible = false
+		overlay.modulate.a = 1.0
 
 
 func _update_display() -> void:

--- a/tests/unit/test_card_attention_highlight.gd
+++ b/tests/unit/test_card_attention_highlight.gd
@@ -1,0 +1,54 @@
+extends GdUnitTestSuite
+
+## Card highlight overlays must survive a same-frame disable/re-enable.
+## Moving the mouse between two pending-effect stack rows that resolve to the
+## same board card fires set_attention_highlight(false) + (true) in one frame;
+## when the disable path used queue_free(), the re-enable picked up the
+## queued-for-deletion overlay and the looping pulse tween ended up targeting
+## a dead node — Godot aborted it with "Infinite loop detected" (tween.cpp)
+## and the highlight vanished. The overlays now hide instead of freeing.
+
+const CARD_SCENE := preload("res://scenes/cards/Card.tscn")
+
+var _card: Node
+
+
+func before_test() -> void:
+	_card = auto_free(CARD_SCENE.instantiate())
+	add_child(_card)
+
+
+func test_attention_highlight_survives_same_frame_toggle() -> void:
+	_card.set_attention_highlight(true)
+	_card.set_attention_highlight(false)
+	_card.set_attention_highlight(true)
+	await await_idle_frame()
+	await await_idle_frame()
+	var overlay: Panel = _card.get_node_or_null("AttentionOverlay")
+	assert_object(overlay).is_not_null()
+	assert_bool(overlay.is_queued_for_deletion()).is_false()
+	assert_bool(overlay.visible).is_true()
+	assert_object(_card._attention_tween).is_not_null()
+	assert_bool(_card._attention_tween.is_running()).is_true()
+
+
+func test_attention_highlight_disable_hides_and_stops_pulse() -> void:
+	_card.set_attention_highlight(true)
+	await await_idle_frame()
+	_card.set_attention_highlight(false)
+	var overlay: Panel = _card.get_node_or_null("AttentionOverlay")
+	assert_object(overlay).is_not_null()
+	assert_bool(overlay.visible).is_false()
+	assert_float(overlay.modulate.a).is_equal(1.0)
+	assert_object(_card._attention_tween).is_null()
+
+
+func test_highlight_survives_same_frame_toggle() -> void:
+	_card.set_highlight(true)
+	_card.set_highlight(false)
+	_card.set_highlight(true)
+	await await_idle_frame()
+	var overlay: Panel = _card.get_node_or_null("HighlightOverlay")
+	assert_object(overlay).is_not_null()
+	assert_bool(overlay.is_queued_for_deletion()).is_false()
+	assert_bool(overlay.visible).is_true()

--- a/tests/unit/test_card_attention_highlight.gd.uid
+++ b/tests/unit/test_card_attention_highlight.gd.uid
@@ -1,0 +1,1 @@
+uid://d1pmqd6rufhk2


### PR DESCRIPTION
Card highlight overlays were freed with queue_free() on disable but looked up with get_node_or_null() on enable. Moving the mouse between two pending-effect stack rows that resolve to the same board card disables and re-enables the highlight in the same frame, so the pulse tween was rebuilt on the queued-for-deletion overlay. Once that node was freed the looping tween had no valid tweeners and Godot aborted it with "Infinite loop detected" (tween.cpp), dropping the highlight.

Hide the overlays instead of freeing them (same pattern as the card badges) and add a regression suite that toggles the highlights within a single frame.