### PR TITLE
Fix host-vs-client display divergences in multiplayer

### DIFF
--- a/scenes/board/game_board.gd
+++ b/scenes/board/game_board.gd
@@ -1335,6 +1335,19 @@ func _on_discard_reshuffled(moved_cards: Array, player_id: int) -> void:
 # --- Action handler visual feedback ---
 
 func _on_play_cancelled(player_id: int) -> void:
+	if is_multiplayer_game and player_id != local_player_id:
+		# The acting player's dragged card lives on their screen — tell that
+		# peer to restore it (board state arrives via the snapshot broadcast).
+		for peer_id in NetworkManager.peer_player_map:
+			if NetworkManager.peer_player_map[peer_id] == player_id:
+				RpcLogger.log_send("play_cancelled", 4)
+				_sync._rpc_play_cancelled.rpc_id(peer_id, player_id)
+	_restore_cancelled_play(player_id)
+	# Sync boards in case the cost prompt changed hand/discard state
+	_sync_boards()
+
+
+func _restore_cancelled_play(player_id: int) -> void:
 	# Reset the dragged card's scale/state and tween it back to its slot.
 	_clear_card_highlight()
 	var board: Control = player1_board if player_id == 0 else player2_board
@@ -1351,8 +1364,6 @@ func _on_play_cancelled(player_id: int) -> void:
 		# at its drop position. Move only that card back to its slot — leave
 		# the rest of the player's hand order untouched.
 		board.hand_manager.restore_drop_handled_card_position()
-	# Sync boards in case the cost prompt changed hand/discard state
-	_sync_boards()
 
 
 func _on_battle_card_played(_player_id: int, _card: Dictionary, _zone_index: int) -> void:
@@ -1599,6 +1610,7 @@ func _execute_rematch() -> void:
 	monster_deck_view_overlay.visible = false
 	zone_stack_view_overlay.visible = false
 	card_zoom_overlay.visible = false
+	hide_ability_banner()
 
 	# 6. Reset client state
 	_client_players = [PlayerState.new(0), PlayerState.new(1)]
@@ -2291,9 +2303,17 @@ func _play_action_required_if_not_turn_player(player_id: int) -> void:
 		SfxManager.play("action_required")
 
 
+## Hide the active-ability banner and drop any stale remote-banner data
+## (game end and rematch cleanup — a mid-effect banner must not persist).
+func hide_ability_banner() -> void:
+	_router.set_remote_banner("", "")
+	_ability_banner.hide_banner()
+
+
 ## Router handler for monster rank-up: board-side button state wraps the
 ## viewer's mandatory selection mode.
 func _show_monster_rankup(monsters: Array, valid_indices: Array[int], prompt: String, resolve_cb: Callable) -> void:
+	_play_action_required_if_not_turn_player(local_player_id)
 	_disable_all_buttons()
 	monster_deck_view_overlay.show_rankup(monsters, valid_indices, prompt, func(index: int) -> void:
 		btn_confirm.disabled = true
@@ -2976,19 +2996,30 @@ func _rpc_monster_rankup_requested(monsters_json: String, indices_json: String, 
 		return
 	var monster_ids: Array = JSON.parse_string(monsters_json)
 	var parsed_indices: Array = JSON.parse_string(indices_json)
-	SfxManager.play("action_required")
+	if _client_current_player_id != local_player_id:
+		SfxManager.play("action_required")
 	_router.show_monster_rankup(StateCodec.ids_to_cards(monster_ids), parsed_indices, prompt)
 
 
-## Server -> Client (dedicated only): display-only cards-revealed overlay
-## (the server already resolved the effect; dismissing changes nothing).
+## Host/Server -> Client: display-only cards-revealed overlay (the host
+## already resolves the effect; dismissing only hides the local overlay).
+## Routed through the router so the ability banner shows above it.
 func _rpc_cards_revealed_shown(cards_json: String, title: String) -> void:
 	if NetworkManager.is_host():
 		return
 	var ids: Variant = JSON.parse_string(cards_json)
 	if not ids is Array or ids.is_empty():
 		return
-	zone_stack_view_overlay.show_revealed(StateCodec.ids_to_cards(ids), _resolve_translated_text(title), Callable())
+	_router.show_cards_revealed(StateCodec.ids_to_cards(ids), title)
+
+
+## Host -> Client: a pending play was cancelled (cost declined / invasion
+## aborted) — restore the card this client dragged onto a zone to its hand.
+func _rpc_play_cancelled(player_id: int) -> void:
+	RpcLogger.log_receive("play_cancelled", 4)
+	if NetworkManager.is_host():
+		return
+	_restore_cancelled_play(player_id)
 
 
 ## Host -> Client: highlight a zone card during effect resolution

--- a/scenes/board/modules/end_game_controller.gd
+++ b/scenes/board/modules/end_game_controller.gd
@@ -43,6 +43,7 @@ func on_game_ended(winner_id: int, reason_key: String) -> void:
 	SfxManager.play("game_win" if winner_id == _board.local_player_id else "game_lose")
 	_board._action_pending = false
 	_board._game_ended_by_disconnect = false
+	_board.hide_ability_banner()
 	# Defensive: hide reconnect overlay if game ends normally
 	if _board._waiting_for_reconnect:
 		_board._waiting_for_reconnect = false
@@ -278,6 +279,7 @@ func rpc_receive_game_ended(winner_id: int, reason_key: String) -> void:
 	SfxManager.play("game_win" if winner_id == _board.local_player_id else "game_lose")
 	_board._action_pending = false
 	_board._game_ended_by_disconnect = false
+	_board.hide_ability_banner()
 	rematch_requested = false
 	opponent_rematch_requested = false
 	_board.end_game_panel.visible = true

--- a/scripts/session/effect_ui_router.gd
+++ b/scripts/session/effect_ui_router.gd
@@ -198,6 +198,16 @@ func _active_summary() -> Dictionary:
 	return _remote_banner
 
 
+## Reconnect support: re-send the ability banner ahead of a replayed prompt
+## so the client's gallery modal comes back with its "which ability" header.
+## No-op for prompt methods that don't carry the banner.
+func resend_banner(method: String, peer_id: int) -> void:
+	if method not in _BANNER_KEYS:
+		return
+	var summary := _active_summary()
+	multiplayer_sync._rpc_ability_banner.rpc_id(peer_id, summary.get("card_id", ""), summary.get("label", ""))
+
+
 ## Client peers: store the banner data for the incoming prompt (set via the
 ## ability-banner RPC just before the prompt RPC).
 func set_remote_banner(card_id: String, label: String) -> void:
@@ -296,7 +306,9 @@ func _on_cards_revealed_requested(player_id: int, cards: Array, title: String) -
 		# resolving synchronously during this emit would fire the resolved signal
 		# before reveal_cards() reaches its await, hanging the effect.
 		var ids_json := JSON.stringify(StateCodec.cards_to_ids(cards))
+		var summary := _active_summary()
 		for peer_id in net.peer_player_map:
+			multiplayer_sync._rpc_ability_banner.rpc_id(peer_id, summary.get("card_id", ""), summary.get("label", ""))
 			multiplayer_sync._rpc_cards_revealed_shown.rpc_id(peer_id, ids_json, title)
 		session.player_input.resolve_cards_revealed.call_deferred()
 		return
@@ -306,8 +318,10 @@ func _on_cards_revealed_requested(player_id: int, cards: Array, title: String) -
 	show_cards_revealed(cards, title)
 	if is_multiplayer:
 		var revealed_json := JSON.stringify(StateCodec.cards_to_ids(cards))
+		var summary := _active_summary()
 		for peer_id in net.peer_player_map:
 			if net.peer_player_map[peer_id] != local_player_id:
+				multiplayer_sync._rpc_ability_banner.rpc_id(peer_id, summary.get("card_id", ""), summary.get("label", ""))
 				multiplayer_sync._rpc_cards_revealed_shown.rpc_id(peer_id, revealed_json, title)
 
 

--- a/scripts/session/multiplayer_sync.gd
+++ b/scripts/session/multiplayer_sync.gd
@@ -291,6 +291,11 @@ func _pending_matches(method: String) -> bool:
 func _resend_pending_interaction(peer_id: int) -> void:
 	var method: String = _pending_interaction.get("method", "")
 	var args: Array = _pending_interaction.get("args", [])
+	# Gallery prompts carry the active-ability banner; replay it before the
+	# prompt RPC just like the original dispatch (_send_to_remote) did.
+	var router: EffectUIRouter = get_node_or_null("../EffectUIRouter")
+	if router:
+		router.resend_banner(method, peer_id)
 	match method:
 		"action_context":
 			RpcLogger.log_send("receive_action_context", args[0].length() + args[1].length())
@@ -979,6 +984,14 @@ func _rpc_claim_win() -> void:
 func _rpc_cards_revealed_shown(cards_json: String, title: String) -> void:
 	if _board and _board.has_method("_rpc_cards_revealed_shown"):
 		_board._rpc_cards_revealed_shown(cards_json, title)
+
+
+## Host -> Client: a pending play was cancelled (cost declined / invasion
+## aborted) — the acting client restores its dragged card to the hand.
+@rpc("any_peer", "call_remote", "reliable")
+func _rpc_play_cancelled(player_id: int) -> void:
+	if _board and _board.has_method("_rpc_play_cancelled"):
+		_board._rpc_play_cancelled(player_id)
 
 
 # --- Effect highlights ---


### PR DESCRIPTION
Client peers were missing UI feedback the host saw:

- Show the active-ability banner above "cards revealed" overlays on clients: the host now sends the banner RPC with each reveal, and the client routes the overlay through EffectUIRouter.show_cards_revealed instead of calling the overlay directly.
- Mirror play_cancelled to the acting client so a dragged card returns to hand when a play cost is declined or an invasion aborts (new _rpc_play_cancelled; restore body shared via _restore_cancelled_play).
- Re-send the ability banner when a reconnecting client's in-flight gallery prompt is replayed (EffectUIRouter.resend_banner).
- Hide the ability banner on game end and rematch cleanup so a mid-effect banner can't persist over the end panel or next match.
- Make the monster rank-up action_required chime symmetric: gated on "not the turn player" on both seats, like the other prompts.

Verified: 901 unit tests green; server harness 3 games, no desyncs or script errors.