### PR TITLE
Fix analog-trigger actions firing per frame under Steam Input

### DIFF
--- a/scripts/input/gamepad_input.gd
+++ b/scripts/input/gamepad_input.gd
@@ -64,6 +64,14 @@ var controller_type: String = "generic"
 var _map: Dictionary = {}
 ## Held nav directions: physical StringName -> seconds held (for repeat).
 var _nav_held: Dictionary = {}
+## Held rebindable actions: physical StringName -> logical StringName,
+## recorded at press time. Motion-bound actions (the triggers) have no edge
+## memory — a held axis restreams events (Steam Input: every frame) and each
+## one past the deadzone reports is_action_pressed() == true — so without
+## this a held trigger injects its pad_* action once per event. Recording
+## the logical at press time means a rebind mid-hold still releases the
+## action that was actually pressed.
+var _action_held: Dictionary = {}
 ## Rebind capture: while valid, the next capturable physical press calls this
 ## with the captured physical action instead of being translated.
 var _capture_cb: Callable = Callable()
@@ -156,6 +164,7 @@ func cancel_capture() -> void:
 func rebind(logical: StringName, physical: StringName) -> void:
 	if not _map.has(logical) or not GlyphDB.FILE_FOR_PHYSICAL.has(physical):
 		return
+	_flush_action_held()
 	var previous: StringName = _map[logical]
 	for other: StringName in _map:
 		if other != logical and _map[other] == physical:
@@ -166,6 +175,7 @@ func rebind(logical: StringName, physical: StringName) -> void:
 
 
 func reset_to_defaults() -> void:
+	_flush_action_held()
 	_map = GlyphDB.default_map()
 	GameSettings.controller_bindings = {}
 	GameSettings.controller_mapping_type = controller_type
@@ -204,6 +214,10 @@ func translate_event(event: InputEvent) -> void:
 	if not (event is InputEventJoypadButton or event is InputEventJoypadMotion):
 		return
 	_detect_controller_type()
+	# Releases run before every guard below — a release swallowed by the
+	# capture or text-editing early-returns would leave the injected pad_*
+	# action pressed in Input forever.
+	_release_held(event)
 	if _capture_cb.is_valid():
 		_handle_capture(event)
 		return
@@ -227,13 +241,13 @@ func translate_event(event: InputEvent) -> void:
 		(focus_owner as LineEdit).edit()
 		get_viewport().set_input_as_handled()
 		return
-	# Rebindable actions.
+	# Rebindable actions: edge-filtered — a motion-event stream past the
+	# deadzone injects exactly one press (releases handled in _release_held).
 	for logical: StringName in _map:
 		var physical: StringName = _map[logical]
-		if event.is_action_pressed(physical):
+		if event.is_action_pressed(physical) and not _action_held.has(physical):
+			_action_held[physical] = logical
 			_inject(logical, true)
-		elif event.is_action_released(physical):
-			_inject(logical, false)
 	# Fixed dpad navigation (stick handled in _process).
 	for physical: StringName in NAV_PHYSICAL:
 		if event.is_action_pressed(physical):
@@ -297,6 +311,32 @@ func _handle_capture(event: InputEvent) -> void:
 			return
 
 
+func _release_held(event: InputEvent) -> void:
+	for physical: StringName in _action_held.keys(): # keys() copy: safe erase
+		if event.is_action_released(physical):
+			_inject(_action_held[physical], false)
+			_action_held.erase(physical)
+
+
+## Release twins for every held rebindable action; mirrors the
+## set_stick_nav_suppressed flush pattern (a pressed-only synthetic action
+## stays held forever otherwise). Called wherever the matching release event
+## can no longer arrive (disconnect, focus loss) or the map changes under a
+## held button (rebind, reset, controller-type switch).
+func _flush_action_held() -> void:
+	for physical: StringName in _action_held:
+		_inject(_action_held[physical], false)
+	_action_held.clear()
+
+
+func _notification(what: int) -> void:
+	# Godot fires Input.release_pressed_events() on focus loss; flush so
+	# _action_held doesn't desync from Input and swallow the next press.
+	if what == NOTIFICATION_APPLICATION_FOCUS_OUT \
+			or what == NOTIFICATION_WM_WINDOW_FOCUS_OUT:
+		_flush_action_held()
+
+
 func _inject(logical: StringName, pressed: bool) -> void:
 	var ev := InputEventAction.new()
 	ev.action = logical
@@ -355,6 +395,8 @@ func _is_text_editing() -> bool:
 
 
 func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
+	# A pad unplugged mid-hold never sends its release event.
+	_flush_action_held()
 	_detect_controller_type()
 	_log_joypads()
 
@@ -375,6 +417,7 @@ func _detect_controller_type() -> void:
 ## Saved bindings are per controller type (spire behavior): apply them only
 ## when they were saved for the currently detected type.
 func _load_bindings() -> void:
+	_flush_action_held()
 	_map = GlyphDB.default_map()
 	if GameSettings.controller_mapping_type != controller_type:
 		return

--- a/tests/unit/gamepad/test_gamepad_input.gd
+++ b/tests/unit/gamepad/test_gamepad_input.gd
@@ -107,3 +107,136 @@ func test_ui_mirror_covers_nav_and_confirm_cancel() -> void:
 	for direction in ["up", "down", "left", "right"]:
 		assert_that(mirror[StringName("pad_nav_" + direction)]) \
 			.is_equal(StringName("ui_" + direction))
+
+
+# --- Rebindable-action edge tracking -----------------------------------------
+# The triggers are bound to analog axes (project.godot axes 4/5): a held
+# trigger restreams InputEventJoypadMotion (Steam Input: every frame) and each
+# event past the deadzone reports is_action_pressed() == true. Without edge
+# tracking, GamepadInput injected pad_play_card_rage once per event — on Steam
+# Deck one rage discard per frame until the hand was empty.
+
+
+## Records _inject calls instead of touching the real Input singleton.
+class RecordingPad extends "res://scripts/input/gamepad_input.gd":
+	var injections: Array = []
+
+	func _inject(logical: StringName, pressed: bool) -> void:
+		injections.append([logical, pressed])
+
+
+func _recording_pad() -> RecordingPad:
+	var pad: RecordingPad = auto_free(RecordingPad.new())
+	add_child(pad)
+	return pad
+
+
+func _motion(axis: JoyAxis, value: float) -> InputEventJoypadMotion:
+	var ev := InputEventJoypadMotion.new()
+	ev.axis = axis
+	ev.axis_value = value
+	return ev
+
+
+func _button(index: JoyButton, pressed: bool) -> InputEventJoypadButton:
+	var ev := InputEventJoypadButton.new()
+	ev.button_index = index
+	ev.pressed = pressed
+	return ev
+
+
+func test_held_trigger_stream_injects_single_press() -> void:
+	var pad := _recording_pad()
+	for i in 5:
+		pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 1.0))
+	assert_that(pad.injections).is_equal([[&"pad_play_card_rage", true]])
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 0.0))
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 0.0))
+	assert_that(pad.injections).is_equal([
+		[&"pad_play_card_rage", true], [&"pad_play_card_rage", false]])
+
+
+func test_trigger_wobble_above_deadzone_injects_single_press() -> void:
+	var pad := _recording_pad()
+	for value in [1.0, 0.9, 1.0]:
+		pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, value))
+	assert_that(pad.injections).is_equal([[&"pad_play_card_rage", true]])
+
+
+func test_deadzone_crossings_are_genuine_edges() -> void:
+	var pad := _recording_pad()
+	for value in [1.0, 0.0, 1.0]:
+		pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, value))
+	assert_that(pad.injections).is_equal([
+		[&"pad_play_card_rage", true],
+		[&"pad_play_card_rage", false],
+		[&"pad_play_card_rage", true]])
+
+
+func test_below_deadzone_stream_injects_nothing() -> void:
+	var pad := _recording_pad()
+	for i in 3:
+		pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 0.15))
+	assert_that(pad.injections).is_equal([])
+
+
+func test_both_triggers_track_independently() -> void:
+	var pad := _recording_pad()
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 1.0))
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_RIGHT, 1.0))
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 0.0))
+	assert_that(pad.injections).is_equal([
+		[&"pad_play_card_rage", true],
+		[&"pad_play_card_invasion", true],
+		[&"pad_play_card_rage", false]])
+	assert_that(pad._action_held).is_equal(
+		{&"controller_trigger_r": &"pad_play_card_invasion"})
+
+
+func test_duplicate_button_presses_dedupe() -> void:
+	var pad := _recording_pad()
+	pad.translate_event(_button(JOY_BUTTON_A, true))
+	pad.translate_event(_button(JOY_BUTTON_A, true))
+	assert_that(pad.injections).is_equal([[&"pad_confirm", true]])
+	pad.translate_event(_button(JOY_BUTTON_A, false))
+	assert_that(pad.injections).is_equal([
+		[&"pad_confirm", true], [&"pad_confirm", false]])
+
+
+func test_disconnect_flushes_held_actions() -> void:
+	var pad := _recording_pad()
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 1.0))
+	pad._on_joy_connection_changed(0, false)
+	assert_that(pad.injections).is_equal([
+		[&"pad_play_card_rage", true], [&"pad_play_card_rage", false]])
+	assert_that(pad._action_held).is_equal({})
+
+
+func test_rebind_mid_hold_releases_old_logical() -> void:
+	var pad := _recording_pad()
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 1.0))
+	pad.rebind(&"pad_play_card_rage", &"controller_stick_press_l")
+	assert_that(pad.injections).is_equal([
+		[&"pad_play_card_rage", true], [&"pad_play_card_rage", false]])
+	# Nothing maps to the left trigger any more: further axis events no-op.
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 1.0))
+	assert_that(pad.injections.size()).is_equal(2)
+
+
+func test_focus_out_flushes_held_actions() -> void:
+	var pad := _recording_pad()
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 1.0))
+	pad.notification(NOTIFICATION_APPLICATION_FOCUS_OUT)
+	assert_that(pad.injections).is_equal([
+		[&"pad_play_card_rage", true], [&"pad_play_card_rage", false]])
+	assert_that(pad._action_held).is_equal({})
+
+
+func test_release_survives_capture_guard() -> void:
+	var pad := _recording_pad()
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 1.0))
+	pad.begin_capture(func(_physical: StringName) -> void: pass)
+	pad.translate_event(_motion(JOY_AXIS_TRIGGER_LEFT, 0.0))
+	pad.cancel_capture()
+	assert_that(pad.injections).is_equal([
+		[&"pad_play_card_rage", true], [&"pad_play_card_rage", false]])


### PR DESCRIPTION
pad_play_card_rage/invasion bind to the analog triggers (axis motion, not buttons), and the rebindable-action loop in GamepadInput had no edge memory: every InputEventJoypadMotion past the deadzone reports is_action_pressed() == true, and Steam Input restreams a held trigger axis every frame. On Steam Deck one trigger pull injected a rage press per frame, chain-discarding every monster in hand (cursor auto-advances after each discard).

Track held rebindable actions (physical -> logical, recorded at press) so a motion stream injects exactly one press and one release on the deadzone downcross. Releases now run before the capture/text-editing guards, fixing a latent stuck-press when a button was released while a text field edited. Held actions are flushed with release twins wherever the real release can never arrive: pad disconnect, rebind/reset, controller-type switch, and window focus loss (Godot force-releases actions there, which would desync the held set).

Covered by 10 new unit tests driving translate_event directly with fabricated motion/button events via a RecordingPad injection seam.